### PR TITLE
Add linter validation of common prefixes used for modules.

### DIFF
--- a/test/oc-linter-validate.yang
+++ b/test/oc-linter-validate.yang
@@ -9,6 +9,7 @@ module oc-linter-validate {
 
   // import some basic types
   import openconfig-extensions { prefix oc-ext; }
+  import ietf-yang-types { prefix "fish"; }
 
   // meta
   organization "OpenConfig working group";


### PR DESCRIPTION
```
  * (M) plugins/openconfig.py
    - For common modules, validate that the prefixes that are used
      are common across the OpenConfig module set.
  * (M) test/oc-linter-validate.yang
    - Add an invalid import to trigger the case above to demonstrate
      error.
```
