### PR TITLE
Support for omitting / compressing paths in oc-jstree plugin

### DIFF
--- a/openconfig_pyang/plugins/oc_jstree.py
+++ b/openconfig_pyang/plugins/oc_jstree.py
@@ -127,17 +127,6 @@ ol#root  {padding-left: 5px; margin-top: 2px; margin-bottom: 1px;
 }
 
 .tier1  {margin-left: 0;     }
-.tier2  {margin-left: 1.5em; }
-.tier3  {margin-left: 3em;   }
-.tier4  {margin-left: 4.5em; }
-.tier5  {margin-left: 6em;   }
-.tier6  {margin-left: 7.5em; }
-.tier7  {margin-left: 9em;   }
-.tier8  {margin-left: 10.5em;}
-.tier9  {margin-left: 12em;  }
-.tier10 {margin-left: 13.5em;}
-.tier11 {margin-left: 15em;  }
-.tier12 {margin-left: 16.5em;}
 
 .level1 {padding-left: 0;    }
 .level2 {padding-left: 1em;  }
@@ -477,14 +466,14 @@ def print_node(s, module, fd, prefix, ctx, level=0):
            name = force_link(ctx,s,module,name)
         fd.write("""<tr id="%s" class="a">
                        <td nowrap id="p4000">
-                          <div id="p5000" class="tier%s">
+                          <div id="p5000" style="margin-left:%sem;">
                              <a href="#" id="p6000"
                                 onclick="toggleRows(this);return false"
                                 class="folder">&nbsp;
                              </a>
                              <abbr title="%s">%s</abbr>
                           </div>
-                       </td> \n""" %(idstring, level, descrstring, name))
+                       </td> \n""" %(idstring, (level * 1.5 - 1.5), descrstring, name))
         fd.write("""<td nowrap>%s</td>
                     <td nowrap>%s</td>
                     <td nowrap>%s</td>
@@ -513,7 +502,7 @@ def print_node(s, module, fd, prefix, ctx, level=0):
             typename = nodetype
         fd.write("""<tr id="%s" class="a">
                        <td nowrap>
-                          <div id=9999 class=tier%s>
+                          <div id=9999 style="margin-left: %sem;">
                              <a class="%s">&nbsp;</a>
                              <abbr title="%s"> %s %s %s</abbr>
                           </div>
@@ -524,7 +513,7 @@ def print_node(s, module, fd, prefix, ctx, level=0):
                        <td>%s</td>
                        <td>%s</td>
                        <td nowrap>%s</td</tr> \n""" %(idstring,
-                                                      level,
+                                                      (level * 1.5 - 1.5),
                                                       classstring,
                                                       descrstring,
                                                       fontstarttag,


### PR DESCRIPTION
 Options to remove paths from tree display.

This implementation displays paths in the description popup when the --oc-jstree-no-paths option is used.