### PR TITLE
Change enum regex to allow for single-character enum values.

### DIFF
--- a/openconfig_pyang/plugins/openconfig.py
+++ b/openconfig_pyang/plugins/openconfig.py
@@ -711,7 +711,7 @@ class OCLintFunctions(object):
       if re.match(r"[a-z]", enum.arg):
         err_add(ctx.errors, stmt.pos, "OC_ENUM_CASE",
                 (enum.arg, enum.arg.upper()))
-      elif not re.match(r"^[A-Z0-9]?[A-Z0-9\_\.]+$", enum.arg):
+      elif not re.match(r"^[A-Z0-9][A-Z0-9\_\.]{0,}$", enum.arg):
         err_add(ctx.errors, stmt.pos, "OC_ENUM_UNDERSCORES",
                 (enum.arg, enum.arg.upper()))
 

--- a/openconfig_pyang/plugins/openconfig.py
+++ b/openconfig_pyang/plugins/openconfig.py
@@ -711,7 +711,7 @@ class OCLintFunctions(object):
       if re.match(r"[a-z]", enum.arg):
         err_add(ctx.errors, stmt.pos, "OC_ENUM_CASE",
                 (enum.arg, enum.arg.upper()))
-      elif not re.match(r"^[A-Z0-9][A-Z0-9\_\.]+$", enum.arg):
+      elif not re.match(r"^[A-Z0-9]?[A-Z0-9\_\.]+$", enum.arg):
         err_add(ctx.errors, stmt.pos, "OC_ENUM_UNDERSCORES",
                 (enum.arg, enum.arg.upper()))
 


### PR DESCRIPTION
Example:
enum A

Did not notice anything in RFC 6020 or OC Style Guide which does not permit the enum value to be:
* Single character
* Begin with "_"
* Begin with "."