### PR TITLE
Ensure that containers in 'config' containers are not allowed.

### DIFF
--- a/openconfig_pyang/plugins/openconfig.py
+++ b/openconfig_pyang/plugins/openconfig.py
@@ -272,7 +272,7 @@ class OpenConfigPlugin(lint.LintPlugin):
     error.add_error_code(
         "OC_OPSTATE_CONTAINER_NAME", ErrorLevel.MAJOR,
         "element \"%s\" at path \"%s\" should be in a \"config\""
-        "or \"state\" container")
+        " or \"state\" container")
 
     # list keys should be leafrefs to respective value in config / state
     error.add_error_code(

--- a/tests/oclinter/container-in-config/Makefile
+++ b/tests/oclinter/container-in-config/Makefile
@@ -1,0 +1,11 @@
+ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+
+ok:
+	pyang --plugindir $(PLUGIN_DIR) \
+		--openconfig --oc-only -p ${ROOT_DIR}/../common \
+		${ROOT_DIR}/openconfig-testcase-succeed.yang
+
+broken:
+	pyang --plugindir $(PLUGIN_DIR) \
+	    --openconfig --oc-only -p ${ROOT_DIR}/../common \
+			    ${ROOT_DIR}/openconfig-testcase-fail.yang

--- a/tests/oclinter/container-in-config/openconfig-testcase-fail.yang
+++ b/tests/oclinter/container-in-config/openconfig-testcase-fail.yang
@@ -1,0 +1,43 @@
+module openconfig-testcase-fail {
+  prefix "oc-tc";
+  namespace "http://openconfig.net/linter/testcase";
+
+  import openconfig-extensions { prefix oc-ext; }
+
+  description
+    "Failure for the case of having a container in config.";
+
+  oc-ext:openconfig-version "0.0.1";
+
+  revision 2016-09-28 {
+    reference "0.0.1";
+    description
+      "Revision statement";
+  }
+
+  grouping top-config {
+    container not-allowed {
+      leaf a { type string; }
+    }
+    leaf b { type string; }
+  }
+
+  grouping top-state {
+    leaf c { type string; }
+  }
+
+  grouping foo-top {
+     container config {
+        uses top-config;
+     }
+     container state {
+       config false;
+       uses top-config;
+       uses top-state;
+     }
+  }
+
+  uses foo-top;
+
+
+}

--- a/tests/oclinter/container-in-config/openconfig-testcase-succeed.yang
+++ b/tests/oclinter/container-in-config/openconfig-testcase-succeed.yang
@@ -1,0 +1,40 @@
+module openconfig-testcase-succeed {
+  prefix "oc-tc";
+  namespace "http://openconfig.net/linter/testcase";
+
+  import openconfig-extensions { prefix oc-ext; }
+
+  description
+    "Failure for the case of having a container in config.";
+
+  oc-ext:openconfig-version "0.0.1";
+
+  revision 2016-09-28 {
+    reference "0.0.1";
+    description
+      "Revision statement";
+  }
+
+  grouping top-config {
+    leaf b { type string; }
+  }
+
+  grouping top-state {
+    leaf c { type string; }
+  }
+
+  grouping foo-top {
+     container config {
+        uses top-config;
+     }
+     container state {
+       config false;
+       uses top-config;
+       uses top-state;
+     }
+  }
+
+  uses foo-top;
+
+
+}


### PR DESCRIPTION
Ensure that containers in 'config' containers fail the linter test.

```
 * (A) tests/oclinter/container-in-config/*
  - Add testcase to ensure that the linter fails for containers that are
    under 'config' containers.
 * (M) openconfig_pyang/plugins/openconfig.py
  - Fix spacing in an error message.
```