### PR TITLE
Do not error out if list key is not a leafref.

### DIFF
--- a/openconfig_pyang/plugins/openconfig.py
+++ b/openconfig_pyang/plugins/openconfig.py
@@ -839,12 +839,13 @@ class OCLintFunctions(object):
                 stmt.arg)
 
       keypath = keytype.search_one("path")
-      keypathelem = yangpath.split_paths(keypath.arg)
-      for i in range(0,len(keypathelem)):
-        if keypathelem[i] in ["config", "state"]:
-          if len(keypathelem[i+1:]) > 1:
-            err_add(ctx.errors, stmt.pos, "OC_OPSTATE_KEY_LEAFREF_DIRECT",
-                    stmt.arg)
+      if keypath: # only leafrefs have the path attribute.
+        keypathelem = yangpath.split_paths(keypath.arg)
+        for i in range(0,len(keypathelem)):
+          if keypathelem[i] in ["config", "state"]:
+            if len(keypathelem[i+1:]) > 1:
+              err_add(ctx.errors, stmt.pos, "OC_OPSTATE_KEY_LEAFREF_DIRECT",
+                      stmt.arg)
 
       return
 


### PR DESCRIPTION
I couldn't tell whether we require list keys to be leafrefs from the [section on the style guide](https://github.com/openconfig/public/blob/master/doc/openconfig_style_guide.md#list). If so, then I will change this implementation to add an error for that case instead.

Resolves #38 