### PR TITLE
Add rule that surrounding container of a list must be a different name.

### DIFF
--- a/openconfig_pyang/plugins/openconfig.py
+++ b/openconfig_pyang/plugins/openconfig.py
@@ -300,6 +300,12 @@ class OpenConfigPlugin(lint.LintPlugin):
     error.add_error_code("OC_LIST_NO_ENCLOSING_CONTAINER", ErrorLevel.MAJOR,
                          "List %s does not have a surrounding container")
 
+    # a list whose surrounding container has the same name.
+    error.add_error_code(
+        "OC_LIST_SURROUNDING_CONTAINER_NAME_SAME", ErrorLevel.MAJOR,
+        "Surrounding container of list %s has the same name (often this should be the plural version of the list name)"
+    )
+
     # when path compression is performed, the containers surrounding
     # lists are removed, if there are two lists with the same name
     # this results in a name collision.
@@ -869,6 +875,10 @@ class OCLintFunctions(object):
     if stmt.parent.keyword != "container":
       err_add(ctx.errors, stmt.parent.pos, "OC_LIST_NO_ENCLOSING_CONTAINER",
               stmt.arg)
+
+    if stmt.parent.arg == stmt.arg:
+      err_add(ctx.errors, stmt.parent.pos,
+              "OC_LIST_SURROUNDING_CONTAINER_NAME_SAME", stmt.parent.arg)
 
     grandparent = stmt.parent.parent
     for ch in grandparent.i_children:

--- a/tests/oclinter/lists-surrounding-container-name/Makefile
+++ b/tests/oclinter/lists-surrounding-container-name/Makefile
@@ -1,0 +1,11 @@
+ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+
+ok:
+	pyang --plugindir $(PLUGIN_DIR) \
+		--openconfig --oc-only -p ${ROOT_DIR}/../common \
+		${ROOT_DIR}/openconfig-testcase-succeed.yang
+
+broken:
+	pyang --plugindir $(PLUGIN_DIR) \
+	    --openconfig --oc-only -p ${ROOT_DIR}/../common \
+			    ${ROOT_DIR}/openconfig-testcase-fail.yang

--- a/tests/oclinter/lists-surrounding-container-name/openconfig-testcase-fail.yang
+++ b/tests/oclinter/lists-surrounding-container-name/openconfig-testcase-fail.yang
@@ -1,0 +1,47 @@
+module openconfig-testcase-fail {
+  prefix "oc-tc";
+  namespace "http://openconfig.net/linter/testcase";
+
+  import openconfig-extensions { prefix oc-ext; }
+
+  description
+    "Failure test case for a list being within a
+    surrounding container that has the same name.";
+
+  oc-ext:openconfig-version "0.0.1";
+
+  revision 2016-09-28 {
+    reference "0.0.1";
+    description
+      "Revision statement";
+  }
+
+  grouping list-config {
+    leaf keyleaf { type string; }
+  }
+
+  grouping foo-top {
+    container foo {
+      list foo {
+        key "keyleaf";
+
+        leaf keyleaf {
+          type leafref {
+              path "../config/keyleaf";
+          }
+        }
+
+        container config {
+          uses list-config;
+        }
+
+        container state {
+          config false;
+          uses list-config;
+        }
+      }
+    }
+  }
+
+  uses foo-top;
+}

--- a/tests/oclinter/lists-surrounding-container-name/openconfig-testcase-succeed.yang
+++ b/tests/oclinter/lists-surrounding-container-name/openconfig-testcase-succeed.yang
@@ -1,0 +1,47 @@
+module openconfig-testcase-succeed {
+  prefix "oc-tc";
+  namespace "http://openconfig.net/linter/testcase";
+
+  import openconfig-extensions { prefix oc-ext; }
+
+  description
+    "Success test case for a list being within a
+    surrounding container that has the same name.";
+
+  oc-ext:openconfig-version "0.0.1";
+
+  revision 2016-09-28 {
+    reference "0.0.1";
+    description
+      "Revision statement";
+  }
+
+  grouping list-config {
+    leaf keyleaf { type string; }
+  }
+
+  grouping foo-top {
+    container foos {
+      list foo {
+        key "keyleaf";
+
+        leaf keyleaf {
+          type leafref {
+              path "../config/keyleaf";
+          }
+        }
+
+        container config {
+          uses list-config;
+        }
+
+        container state {
+          config false;
+          uses list-config;
+        }
+      }
+    }
+  }
+
+  uses foo-top;
+}


### PR DESCRIPTION
Existing inconsistencies in openconfig/public that must be fixed if we're to introduce this:
```
ate/openconfig-ate-flow.yang:427 (at ate/openconfig-ate-flow.yang:103): error: Surrounding container of list ingress-tracking has the same name (often this should be the plural version of the list name)
ate/openconfig-ate-flow.yang:427 (at ate/openconfig-ate-flow.yang:112): error: Surrounding container of list egress-tracking has the same name (often this should be the plural version of the list name)
ate/openconfig-ate-flow.yang:427 (at ate/openconfig-ate-flow.yang:371): error: Surrounding container of list egress-tracking has the same name (often this should be the plural version of the list name)
macsec/openconfig-macsec.yang:787 (at macsec/openconfig-macsec.yang:428): error: Surrounding container of list scsa-tx has the same name (often this should be the plural version of the list name)
macsec/openconfig-macsec.yang:787 (at macsec/openconfig-macsec.yang:464): error: Surrounding container of list scsa-rx has the same name (often this should be the plural version of the list name)
network-instance/openconfig-network-instance.yang:1349 (at mpls/openconfig-mpls-te.yang:1298): error: Surrounding container of list p2p-primary-path has the same name (often this should be the plural version of the list name)
```

This change will enable a more user-friendly compressed name for uncompressed GoStructs.