### PR TITLE
Add linter check for state container not existing.

### DIFF
--- a/openconfig_pyang/plugins/openconfig.py
+++ b/openconfig_pyang/plugins/openconfig.py
@@ -941,15 +941,16 @@ class OCLintFunctions(object):
       elif c.arg == "state":
         c_state = c
 
-    if None in [c_config, c_state]:
+    if c_config is None:
       return
 
     config_elem_names = [i.arg for i in c_config.i_children
                          if i.arg != "config" and
                          i.keyword in INSTANTIATED_DATA_KEYWORDS]
-    state_elem_names = [i.arg for i in c_state.i_children
-                        if i.arg != "state" and
-                        i.keyword in INSTANTIATED_DATA_KEYWORDS]
+    state_elem_names = []
+    if c_state is not None: 
+      state_elem_names = [i.arg for i in c_state.i_children if i.arg != "state"
+                          and i.keyword in INSTANTIATED_DATA_KEYWORDS]
 
     for elem in config_elem_names:
       if elem not in state_elem_names:

--- a/openconfig_pyang/plugins/openconfig.py
+++ b/openconfig_pyang/plugins/openconfig.py
@@ -931,7 +931,7 @@ class OCLintFunctions(object):
     if stmt.search_one("container") is None:
       return
 
-    containers = stmt.search("container")
+    containers = stmt.search("container", children=stmt.i_children)
     # Only perform this check if this is a container that has both a config
     # and state container
     c_config, c_state = None, None

--- a/tests/oclinter/opstate-applied-config-exists/Makefile
+++ b/tests/oclinter/opstate-applied-config-exists/Makefile
@@ -1,0 +1,11 @@
+ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+
+ok:
+	pyang --plugindir $(PLUGIN_DIR) \
+		--openconfig --oc-only -p ${ROOT_DIR}/../common \
+		${ROOT_DIR}/openconfig-testcase-succeed.yang
+
+broken:
+	pyang --plugindir $(PLUGIN_DIR) \
+	    --openconfig --oc-only -p ${ROOT_DIR}/../common \
+			    ${ROOT_DIR}/openconfig-testcase-fail.yang

--- a/tests/oclinter/opstate-applied-config-exists/openconfig-testcase-fail.yang
+++ b/tests/oclinter/opstate-applied-config-exists/openconfig-testcase-fail.yang
@@ -1,0 +1,33 @@
+module openconfig-testcase-fail {
+  prefix "oc-tc";
+  namespace "http://openconfig.net/linter/testcase";
+
+  import openconfig-extensions { prefix oc-ext; }
+
+  description
+    "Failure test case for missing applied config leaves where the state
+    container doesn't exist.";
+
+  oc-ext:openconfig-version "0.0.1";
+
+  revision 2016-09-28 {
+    reference "0.0.1";
+    description
+      "Revision statement";
+  }
+
+  grouping test-config {
+    leaf tleaf { type string; }
+  }
+
+  grouping foo-top {
+    container test {
+      container config {
+        uses test-config;
+      }
+    }
+  }
+
+  uses foo-top;
+
+}

--- a/tests/oclinter/opstate-applied-config-exists/openconfig-testcase-succeed.yang
+++ b/tests/oclinter/opstate-applied-config-exists/openconfig-testcase-succeed.yang
@@ -5,7 +5,8 @@ module openconfig-testcase-succeed {
   import openconfig-extensions { prefix oc-ext; }
 
   description
-    "Success test case for applied config leaves being present";
+    "Success test case for a complicated case where the state container is
+    defined in a grouping and the config container isn't";
 
   oc-ext:openconfig-version "0.0.1";
 
@@ -16,7 +17,31 @@ module openconfig-testcase-succeed {
   }
 
   grouping test-config {
+  }
+
+  grouping test-grouping-common {
     leaf tleaf { type string; }
+  }
+
+  grouping test-grouping-state {
+    container state {
+      config false;
+      uses test-grouping-common;
+    }
+  }
+
+  grouping input-interface-state {
+    description
+      "State information of interface";
+  }
+
+  grouping test-group {
+    container test-container {
+      container config {
+        uses test-grouping-common;
+      }
+      uses test-grouping-state;
+    }
   }
 
   grouping foo-top {
@@ -27,7 +52,9 @@ module openconfig-testcase-succeed {
       container state {
         config false;
         uses test-config;
+        uses input-interface-state;
       }
+      uses test-group;
     }
   }
 

--- a/tests/oclinter/opstate-applied-config-exists/openconfig-testcase-succeed.yang
+++ b/tests/oclinter/opstate-applied-config-exists/openconfig-testcase-succeed.yang
@@ -1,0 +1,36 @@
+module openconfig-testcase-succeed {
+  prefix "oc-tc";
+  namespace "http://openconfig.net/linter/testcase";
+
+  import openconfig-extensions { prefix oc-ext; }
+
+  description
+    "Success test case for applied config leaves being present";
+
+  oc-ext:openconfig-version "0.0.1";
+
+  revision 2016-09-28 {
+    reference "0.0.1";
+    description
+      "Revision statement";
+  }
+
+  grouping test-config {
+    leaf tleaf { type string; }
+  }
+
+  grouping foo-top {
+    container test {
+      container config {
+        uses test-config;
+      }
+      container state {
+        config false;
+        uses test-config;
+      }
+    }
+  }
+
+  uses foo-top;
+
+}


### PR DESCRIPTION
This will catch the bug not caught at https://github.com/openconfig/public/pull/762

Also work around pyang bug where containers in groupings cannot be searched via `stmt.search`