### PR TITLE
Fix sibling check for lists.

### DIFF
--- a/.github/workflows/py.yml
+++ b/.github/workflows/py.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '2.7', '3.7', '3.8', '3.9', '3.x' ]
+        python-version: [ '3.9', '3.10', '3.11', '3.12', '3.x' ]
       fail-fast: false
     name: Python ${{ matrix.python-version }} Packaging Test
 

--- a/.github/workflows/py.yml
+++ b/.github/workflows/py.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.9', '3.10', '3.11', '3.12', '3.x' ]
+        python-version: [ '3.9', '3.10', '3.11' ]
       fail-fast: false
     name: Python ${{ matrix.python-version }} Packaging Test
 

--- a/tests/oclinter/lists-no-sibling-augment/Makefile
+++ b/tests/oclinter/lists-no-sibling-augment/Makefile
@@ -1,0 +1,11 @@
+ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+
+ok:
+	pyang --plugindir $(PLUGIN_DIR) \
+		--openconfig --oc-only -p ${ROOT_DIR}/../common \
+		${ROOT_DIR}/openconfig-testcase-succeed.yang
+
+broken:
+	pyang --plugindir $(PLUGIN_DIR) \
+	    --openconfig --oc-only -p ${ROOT_DIR}/../common \
+			    ${ROOT_DIR}/openconfig-testcase-fail.yang ${ROOT_DIR}/openconfig-testcase-fail-augment.yang

--- a/tests/oclinter/lists-no-sibling-augment/openconfig-testcase-fail-augment.yang
+++ b/tests/oclinter/lists-no-sibling-augment/openconfig-testcase-fail-augment.yang
@@ -1,0 +1,33 @@
+module openconfig-testcase-fail-augment {
+  prefix "oc-tc2";
+  namespace "http://openconfig.net/linter/testcase2";
+
+  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-testcase-fail { prefix oc-tc; }
+
+  description
+    "Failure test case for a list having siblings.";
+
+  oc-ext:openconfig-version "0.0.1";
+
+  revision 2016-09-28 {
+    reference "0.0.1";
+    description
+      "Revision statement";
+  }
+
+  grouping augment-top {
+    container hello {
+      container state {
+        config false;
+        leaf hello-leaf { type string; }
+      }
+    }
+  }
+
+
+  augment '/oc-tc:surrounding-container' {
+    uses augment-top;
+  }
+
+}

--- a/tests/oclinter/lists-no-sibling-augment/openconfig-testcase-fail.yang
+++ b/tests/oclinter/lists-no-sibling-augment/openconfig-testcase-fail.yang
@@ -1,0 +1,47 @@
+module openconfig-testcase-fail {
+  prefix "oc-tc";
+  namespace "http://openconfig.net/linter/testcase";
+
+  import openconfig-extensions { prefix oc-ext; }
+
+  description
+    "Failure test case for a list having siblings.";
+
+  oc-ext:openconfig-version "0.0.1";
+
+  revision 2016-09-28 {
+    reference "0.0.1";
+    description
+      "Revision statement";
+  }
+
+  grouping list-config {
+    leaf keyleaf { type string; }
+  }
+
+  grouping foo-top {
+    container surrounding-container {
+      list the-list {
+        key "keyleaf";
+
+        leaf keyleaf {
+          type leafref {
+            path "../config/keyleaf";
+          }
+        }
+
+        container config {
+          uses list-config;
+        }
+
+        container state {
+          config false;
+          uses list-config;
+        }
+      }
+    }
+  }
+
+  uses foo-top;
+
+}

--- a/tests/oclinter/lists-no-sibling-augment/openconfig-testcase-succeed.yang
+++ b/tests/oclinter/lists-no-sibling-augment/openconfig-testcase-succeed.yang
@@ -1,0 +1,47 @@
+module openconfig-testcase-succeed {
+  prefix "oc-tc";
+  namespace "http://openconfig.net/linter/testcase";
+
+  import openconfig-extensions { prefix oc-ext; }
+
+  description
+    "Success test case for a list having siblings.";
+
+  oc-ext:openconfig-version "0.0.1";
+
+  revision 2016-09-28 {
+    reference "0.0.1";
+    description
+      "Revision statement";
+  }
+
+  grouping list-config {
+    leaf keyleaf { type string; }
+  }
+
+  grouping foo-top {
+    container surrounding-container {
+      list the-list {
+        key "keyleaf";
+
+        leaf keyleaf {
+          type leafref {
+            path "../config/keyleaf";
+          }
+        }
+
+        container config {
+          uses list-config;
+        }
+
+        container state {
+          config false;
+          uses list-config;
+        }
+      }
+    }
+  }
+
+  uses foo-top;
+
+}

--- a/tests/oclinter/lists-no-sibling/Makefile
+++ b/tests/oclinter/lists-no-sibling/Makefile
@@ -1,0 +1,11 @@
+ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+
+ok:
+	pyang --plugindir $(PLUGIN_DIR) \
+		--openconfig --oc-only -p ${ROOT_DIR}/../common \
+		${ROOT_DIR}/openconfig-testcase-succeed.yang
+
+broken:
+	pyang --plugindir $(PLUGIN_DIR) \
+	    --openconfig --oc-only -p ${ROOT_DIR}/../common \
+			    ${ROOT_DIR}/openconfig-testcase-fail.yang

--- a/tests/oclinter/lists-no-sibling/openconfig-testcase-fail.yang
+++ b/tests/oclinter/lists-no-sibling/openconfig-testcase-fail.yang
@@ -1,0 +1,54 @@
+module openconfig-testcase-fail {
+  prefix "oc-tc";
+  namespace "http://openconfig.net/linter/testcase";
+
+  import openconfig-extensions { prefix oc-ext; }
+
+  description
+    "Failure test case for a list having siblings.";
+
+  oc-ext:openconfig-version "0.0.1";
+
+  revision 2016-09-28 {
+    reference "0.0.1";
+    description
+      "Revision statement";
+  }
+
+  grouping list-config {
+    leaf keyleaf { type string; }
+  }
+
+  grouping foo-top {
+    container surrounding-container {
+      container hello {
+        container state {
+          config false;
+          leaf hello-leaf { type string; }
+        }
+      }
+
+      list the-list {
+        key "keyleaf";
+
+        leaf keyleaf {
+          type leafref {
+            path "../config/keyleaf";
+          }
+        }
+
+        container config {
+          uses list-config;
+        }
+
+        container state {
+          config false;
+          uses list-config;
+        }
+      }
+    }
+  }
+
+  uses foo-top;
+
+}

--- a/tests/oclinter/lists-no-sibling/openconfig-testcase-succeed.yang
+++ b/tests/oclinter/lists-no-sibling/openconfig-testcase-succeed.yang
@@ -1,0 +1,47 @@
+module openconfig-testcase-succeed {
+  prefix "oc-tc";
+  namespace "http://openconfig.net/linter/testcase";
+
+  import openconfig-extensions { prefix oc-ext; }
+
+  description
+    "Success test case for a list having siblings.";
+
+  oc-ext:openconfig-version "0.0.1";
+
+  revision 2016-09-28 {
+    reference "0.0.1";
+    description
+      "Revision statement";
+  }
+
+  grouping list-config {
+    leaf keyleaf { type string; }
+  }
+
+  grouping foo-top {
+    container surrounding-container {
+      list the-list {
+        key "keyleaf";
+
+        leaf keyleaf {
+          type leafref {
+            path "../config/keyleaf";
+          }
+        }
+
+        container config {
+          uses list-config;
+        }
+
+        container state {
+          config false;
+          uses list-config;
+        }
+      }
+    }
+  }
+
+  uses foo-top;
+
+}

--- a/tests/packaging.sh
+++ b/tests/packaging.sh
@@ -15,7 +15,7 @@
 
 TESTDIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-$TESTDIR/tvirtenv/bin/pip install setuptools==58.2.0
+pip install setuptools==58.2.0
 
 cd $TESTDIR/..
 rm -rf $TESTDIR/tvirtenv $TESTDIR/../dist $TESTDIR/../build $TESTDIR/../openconfig_pyang.egg-info

--- a/tests/packaging.sh
+++ b/tests/packaging.sh
@@ -15,6 +15,8 @@
 
 TESTDIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+$TESTDIR/tvirtenv/bin/pip install setuptools==58.2.0
+
 cd $TESTDIR/..
 rm -rf $TESTDIR/tvirtenv $TESTDIR/../dist $TESTDIR/../build $TESTDIR/../openconfig_pyang.egg-info
 


### PR DESCRIPTION
The existing check does not work if some of the nodes are augmented into the surrounding container (see https://github.com/openconfig/public/issues/991).

* Removed old check and added new check.
* Added tests for both cases.
* Added a nil check for check_list_enclosing_container.

Tested at https://github.com/openconfig/public/pull/993